### PR TITLE
Add Next.js dashboard scaffold with Tailwind and mock modules

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.11",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.4",
+    "postcss": "8.4.39",
+    "tailwindcss": "3.4.7",
+    "typescript": "5.5.4"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/src/app/advertising/page.tsx
+++ b/apps/web/src/app/advertising/page.tsx
@@ -1,0 +1,20 @@
+import { BarChart } from '@/components/BarChart';
+import { MetricCard } from '@/components/MetricCard';
+import { TopBar } from '@/components/TopBar';
+import { advertisingSpend, dashboardMetrics } from '@/lib/mock-data';
+
+export default function AdvertisingPage() {
+  return (
+    <main>
+      <TopBar title="Advertising" subtitle="Measure channel performance and ROI." />
+      <div className="space-y-6 px-6 py-6 lg:px-10">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {dashboardMetrics.map((metric) => (
+            <MetricCard key={metric.title} {...metric} />
+          ))}
+        </section>
+        <BarChart title="Channel spend" data={advertisingSpend} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/expenses/page.tsx
+++ b/apps/web/src/app/expenses/page.tsx
@@ -1,0 +1,20 @@
+import { ExpenseList } from '@/components/ExpenseList';
+import { MetricCard } from '@/components/MetricCard';
+import { TopBar } from '@/components/TopBar';
+import { dashboardMetrics, expensesList } from '@/lib/mock-data';
+
+export default function ExpensesPage() {
+  return (
+    <main>
+      <TopBar title="Expenses" subtitle="Review operational costs and budgets." />
+      <div className="space-y-6 px-6 py-6 lg:px-10">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {dashboardMetrics.map((metric) => (
+            <MetricCard key={metric.title} {...metric} />
+          ))}
+        </section>
+        <ExpenseList expenses={expensesList} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}
+
+main {
+  @apply min-h-screen;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import { Sidebar } from '@/components/Sidebar';
+
+export const metadata: Metadata = {
+  title: 'Commerce Hub',
+  description: 'Operations dashboard for commerce teams.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-slate-50">
+        <div className="flex min-h-screen">
+          <Sidebar />
+          <div className="flex w-full flex-1 flex-col">{children}</div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/orders/page.tsx
+++ b/apps/web/src/app/orders/page.tsx
@@ -1,0 +1,20 @@
+import { DataTable } from '@/components/DataTable';
+import { MetricCard } from '@/components/MetricCard';
+import { TopBar } from '@/components/TopBar';
+import { dashboardMetrics, ordersTable } from '@/lib/mock-data';
+
+export default function OrdersPage() {
+  return (
+    <main>
+      <TopBar title="Orders" subtitle="Track fulfillment, delivery, and returns." />
+      <div className="space-y-6 px-6 py-6 lg:px-10">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {dashboardMetrics.map((metric) => (
+            <MetricCard key={metric.title} {...metric} />
+          ))}
+        </section>
+        <DataTable title="Order activity" rows={ordersTable} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,24 @@
+import { BarChart } from '@/components/BarChart';
+import { DataTable } from '@/components/DataTable';
+import { MetricCard } from '@/components/MetricCard';
+import { TopBar } from '@/components/TopBar';
+import { advertisingSpend, dashboardMetrics, ordersTable } from '@/lib/mock-data';
+
+export default function DashboardPage() {
+  return (
+    <main>
+      <TopBar title="Dashboard" subtitle="Monitor performance across your commerce stack." />
+      <div className="space-y-6 px-6 py-6 lg:px-10">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {dashboardMetrics.map((metric) => (
+            <MetricCard key={metric.title} {...metric} />
+          ))}
+        </section>
+        <section className="grid gap-6 xl:grid-cols-[2fr,1fr]">
+          <DataTable title="Latest orders" rows={ordersTable} />
+          <BarChart title="Advertising spend" data={advertisingSpend} />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/products/page.tsx
+++ b/apps/web/src/app/products/page.tsx
@@ -1,0 +1,20 @@
+import { DataTable } from '@/components/DataTable';
+import { MetricCard } from '@/components/MetricCard';
+import { TopBar } from '@/components/TopBar';
+import { dashboardMetrics, productsTable } from '@/lib/mock-data';
+
+export default function ProductsPage() {
+  return (
+    <main>
+      <TopBar title="Products" subtitle="Keep inventory and pricing aligned." />
+      <div className="space-y-6 px-6 py-6 lg:px-10">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {dashboardMetrics.map((metric) => (
+            <MetricCard key={metric.title} {...metric} />
+          ))}
+        </section>
+        <DataTable title="Inventory status" rows={productsTable} />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/BarChart.tsx
+++ b/apps/web/src/components/BarChart.tsx
@@ -1,0 +1,30 @@
+import type { ChannelSpend } from '@/lib/mock-data';
+
+export function BarChart({ title, data }: { title: string; data: ChannelSpend[] }) {
+  const maxValue = Math.max(...data.map((item) => item.spend));
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+        <span className="text-xs font-semibold text-slate-400">Last 30 days</span>
+      </div>
+      <div className="mt-6 space-y-4">
+        {data.map((item) => {
+          const width = `${Math.round((item.spend / maxValue) * 100)}%`;
+          return (
+            <div key={item.channel}>
+              <div className="flex items-center justify-between text-sm text-slate-600">
+                <span>{item.channel}</span>
+                <span className="font-semibold text-slate-900">${item.spend.toLocaleString()}</span>
+              </div>
+              <div className="mt-2 h-2 w-full rounded-full bg-slate-100">
+                <div className="h-2 rounded-full bg-brand-500" style={{ width }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/DataTable.tsx
+++ b/apps/web/src/components/DataTable.tsx
@@ -1,0 +1,57 @@
+import type { TableRow } from '@/lib/mock-data';
+
+const statusClasses: Record<string, string> = {
+  Processing: 'text-amber-700 bg-amber-50',
+  Shipped: 'text-blue-700 bg-blue-50',
+  Delivered: 'text-emerald-700 bg-emerald-50',
+  Refunded: 'text-rose-700 bg-rose-50',
+  'In Stock': 'text-emerald-700 bg-emerald-50',
+  'Low Stock': 'text-amber-700 bg-amber-50',
+  Backorder: 'text-rose-700 bg-rose-50'
+};
+
+export function DataTable({ title, rows }: { title: string; rows: TableRow[] }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+        <button className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:border-slate-300">
+          View all
+        </button>
+      </div>
+      <div className="mt-4 overflow-hidden rounded-xl border border-slate-100">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="px-4 py-3">ID</th>
+              <th className="px-4 py-3">Details</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3 text-right">Amount</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {rows.map((row) => (
+              <tr key={row.id} className="bg-white">
+                <td className="px-4 py-3 font-medium text-slate-700">{row.id}</td>
+                <td className="px-4 py-3 text-slate-500">
+                  <div>{row.customer ?? row.product}</div>
+                  <div className="text-xs text-slate-400">{row.date}</div>
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`rounded-full px-2 py-1 text-xs font-semibold ${
+                      statusClasses[row.status] ?? 'text-slate-600 bg-slate-100'
+                    }`}
+                  >
+                    {row.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right font-semibold text-slate-700">{row.amount}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ExpenseList.tsx
+++ b/apps/web/src/components/ExpenseList.tsx
@@ -1,0 +1,26 @@
+import type { Expense } from '@/lib/mock-data';
+
+export function ExpenseList({ expenses }: { expenses: Expense[] }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">Expense breakdown</h2>
+        <span className="text-xs font-semibold text-slate-400">Monthly</span>
+      </div>
+      <ul className="mt-6 space-y-4">
+        {expenses.map((expense) => (
+          <li
+            key={expense.category}
+            className="flex items-center justify-between rounded-xl border border-slate-100 px-4 py-3"
+          >
+            <div>
+              <p className="text-sm font-semibold text-slate-700">{expense.category}</p>
+              <p className="text-xs text-slate-400">Owner: {expense.owner}</p>
+            </div>
+            <p className="text-sm font-semibold text-slate-900">{expense.amount}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/MetricCard.tsx
+++ b/apps/web/src/components/MetricCard.tsx
@@ -1,0 +1,20 @@
+import type { Metric } from '@/lib/mock-data';
+
+const trendStyles = {
+  up: 'text-emerald-600 bg-emerald-50',
+  down: 'text-rose-600 bg-rose-50'
+};
+
+export function MetricCard({ title, value, change, trend }: Metric) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-slate-500">{title}</p>
+        <span className={`rounded-full px-2 py-1 text-xs font-semibold ${trendStyles[trend]}`}>
+          {change}
+        </span>
+      </div>
+      <p className="mt-4 text-3xl font-semibold text-slate-900">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+const links = [
+  { href: '/', label: 'Dashboard' },
+  { href: '/orders', label: 'Orders' },
+  { href: '/products', label: 'Products' },
+  { href: '/advertising', label: 'Advertising' },
+  { href: '/expenses', label: 'Expenses' }
+];
+
+export function Sidebar() {
+  return (
+    <aside className="hidden w-64 flex-col gap-6 border-r border-slate-200 bg-white p-6 lg:flex">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">eNgine9r</p>
+        <h1 className="mt-2 text-2xl font-semibold text-slate-900">Commerce Hub</h1>
+      </div>
+      <nav className="flex flex-col gap-2">
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="rounded-xl px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+      <div className="rounded-2xl bg-slate-50 p-4 text-sm text-slate-500">
+        <p className="font-semibold text-slate-700">Next steps</p>
+        <p className="mt-2">Connect your data sources to replace the mock modules.</p>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/TopBar.tsx
+++ b/apps/web/src/components/TopBar.tsx
@@ -1,0 +1,16 @@
+export function TopBar({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <header className="flex flex-col gap-2 border-b border-slate-200 bg-white px-6 py-4 lg:px-10">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-500">Overview</p>
+      <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+          <p className="text-sm text-slate-500">{subtitle}</p>
+        </div>
+        <button className="mt-3 rounded-full bg-brand-500 px-4 py-2 text-xs font-semibold text-white shadow-sm md:mt-0">
+          Download report
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/lib/mock-data.ts
+++ b/apps/web/src/lib/mock-data.ts
@@ -1,0 +1,61 @@
+export type Metric = {
+  title: string;
+  value: string;
+  change: string;
+  trend: 'up' | 'down';
+};
+
+export type TableRow = {
+  id: string;
+  status: string;
+  customer?: string;
+  product?: string;
+  amount: string;
+  date: string;
+};
+
+export type ChannelSpend = {
+  channel: string;
+  spend: number;
+};
+
+export type Expense = {
+  category: string;
+  amount: string;
+  owner: string;
+};
+
+export const dashboardMetrics: Metric[] = [
+  { title: 'Total Revenue', value: '$128,430', change: '+12.4%', trend: 'up' },
+  { title: 'Orders', value: '1,284', change: '+4.1%', trend: 'up' },
+  { title: 'Active Products', value: '312', change: '-1.2%', trend: 'down' },
+  { title: 'Ad Spend', value: '$24,980', change: '+6.8%', trend: 'up' }
+];
+
+export const ordersTable: TableRow[] = [
+  { id: 'ORD-9201', status: 'Processing', customer: 'Ava Williams', amount: '$1,240', date: 'Aug 15' },
+  { id: 'ORD-9202', status: 'Shipped', customer: 'Lucas Chen', amount: '$980', date: 'Aug 14' },
+  { id: 'ORD-9203', status: 'Delivered', customer: 'Noah Patel', amount: '$3,180', date: 'Aug 14' },
+  { id: 'ORD-9204', status: 'Refunded', customer: 'Sofia Reyes', amount: '$420', date: 'Aug 13' }
+];
+
+export const productsTable: TableRow[] = [
+  { id: 'PRD-401', status: 'In Stock', product: 'Nimbus Backpack', amount: '$74', date: 'Updated 2d ago' },
+  { id: 'PRD-402', status: 'Low Stock', product: 'Crescent Hoodie', amount: '$64', date: 'Updated 1d ago' },
+  { id: 'PRD-403', status: 'Backorder', product: 'Atlas Sneaker', amount: '$132', date: 'Updated 4d ago' },
+  { id: 'PRD-404', status: 'In Stock', product: 'Solstice Tee', amount: '$38', date: 'Updated 3d ago' }
+];
+
+export const advertisingSpend: ChannelSpend[] = [
+  { channel: 'Search', spend: 14800 },
+  { channel: 'Social', spend: 9200 },
+  { channel: 'Affiliates', spend: 4800 },
+  { channel: 'Email', spend: 2100 }
+];
+
+export const expensesList: Expense[] = [
+  { category: 'Fulfillment', amount: '$12,400', owner: 'Operations' },
+  { category: 'Payroll', amount: '$38,900', owner: 'People Ops' },
+  { category: 'Software', amount: '$6,250', owner: 'IT' },
+  { category: 'Facilities', amount: '$4,800', owner: 'Facilities' }
+];

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,26 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          50: '#f1f5ff',
+          100: '#e0e8ff',
+          200: '#c1d2ff',
+          300: '#92b1ff',
+          400: '#5d86ff',
+          500: '#365fff',
+          600: '#1f3ee6',
+          700: '#1d33b8',
+          800: '#1c2f92',
+          900: '#1c2b73'
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight Next.js app scaffold to iterate on a commerce operations dashboard UI before backend integration.
- Deliver page routes for common modules so designers and engineers can validate layouts and navigation (`Dashboard`, `Orders`, `Products`, `Advertising`, `Expenses`).
- Include reusable UI primitives and mock data so pages are functional without external APIs.

### Description
- Add a new app under `apps/web` with Next.js + TypeScript configuration files (`package.json`, `tsconfig.json`, `next.config.js`, `next-env.d.ts`).
- Configure Tailwind (`tailwind.config.ts`, `postcss.config.js`, `src/app/globals.css`) and set up the app router layout in `src/app/layout.tsx`.
- Implement pages for `Dashboard`, `Orders`, `Products`, `Advertising`, and `Expenses` in `src/app/*/page.tsx` wired to mock data from `src/lib/mock-data.ts`.
- Create reusable components in `src/components/` including `MetricCard`, `DataTable`, `BarChart`, `ExpenseList`, `Sidebar`, and `TopBar` to be reused across pages.

### Testing
- No automated tests were executed because package installation and runtime verification were blocked by npm registry access errors (`E403`), preventing `npm install` and `next dev` from running.
- No build or lint runs were performed in CI due to the same package-install restriction, so changes were validated by static file creation only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985fc64febc832a8948e00dc4a11edc)