### PR TITLE
Add Node.js API with metrics logic and REST endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "engine9r-api",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "node --watch src/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  }
+}

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,0 +1,16 @@
+const express = require("express");
+const cors = require("cors");
+const routes = require("./routes");
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.use("/api", routes);
+
+module.exports = app;

--- a/apps/api/src/db/data.js
+++ b/apps/api/src/db/data.js
@@ -1,0 +1,98 @@
+const orders = [
+  {
+    id: "ord_1001",
+    productId: "prod_1",
+    quantity: 2,
+    total: 240,
+    currency: "USD",
+    orderedAt: "2024-05-01"
+  },
+  {
+    id: "ord_1002",
+    productId: "prod_2",
+    quantity: 1,
+    total: 130,
+    currency: "USD",
+    orderedAt: "2024-05-02"
+  },
+  {
+    id: "ord_1003",
+    productId: "prod_3",
+    quantity: 3,
+    total: 315,
+    currency: "USD",
+    orderedAt: "2024-05-03"
+  }
+];
+
+const products = [
+  {
+    id: "prod_1",
+    name: "Starter Kit",
+    price: 120,
+    currency: "USD"
+  },
+  {
+    id: "prod_2",
+    name: "Growth Bundle",
+    price: 130,
+    currency: "USD"
+  },
+  {
+    id: "prod_3",
+    name: "Enterprise Pack",
+    price: 105,
+    currency: "USD"
+  }
+];
+
+const adSpend = [
+  {
+    id: "ads_2001",
+    channel: "Search",
+    amount: 220,
+    currency: "USD",
+    date: "2024-05-01"
+  },
+  {
+    id: "ads_2002",
+    channel: "Social",
+    amount: 180,
+    currency: "USD",
+    date: "2024-05-02"
+  }
+];
+
+const expenses = [
+  {
+    id: "exp_3001",
+    name: "Software Subscriptions",
+    amount: 900,
+    currency: "USD",
+    cadence: "monthly",
+    type: "fixed"
+  },
+  {
+    id: "exp_3002",
+    name: "Warehouse Rent",
+    amount: 1500,
+    currency: "USD",
+    cadence: "monthly",
+    type: "fixed"
+  },
+  {
+    id: "exp_3003",
+    name: "Packaging",
+    amount: 120,
+    currency: "USD",
+    cadence: "per-order",
+    type: "variable"
+  }
+];
+
+module.exports = {
+  orders,
+  products,
+  adSpend,
+  expenses
+};

--- a/apps/api/src/logic/dashboard.js
+++ b/apps/api/src/logic/dashboard.js
@@ -1,0 +1,50 @@
+const { listOrders } = require("../services/ordersService");
+const { listProducts } = require("../services/productsService");
+const { listAdSpend } = require("../services/adSpendService");
+const { listExpenses } = require("../services/expensesService");
+const {
+  calculateRevenue,
+  calculateAdSpend,
+  calculateFixedExpensesPerDay,
+  calculateProfit,
+  calculateRoas,
+  calculateMarginPercent
+} = require("./metrics");
+
+const getDashboardMetrics = () => {
+  const orders = listOrders();
+  const products = listProducts();
+  const adSpend = listAdSpend();
+  const expenses = listExpenses();
+
+  const revenue = calculateRevenue(orders);
+  const totalAdSpend = calculateAdSpend(adSpend);
+  const fixedExpensesPerDay = calculateFixedExpensesPerDay(expenses);
+  const profit = calculateProfit(revenue, totalAdSpend, fixedExpensesPerDay);
+  const roas = calculateRoas(revenue, totalAdSpend);
+  const marginPercent = calculateMarginPercent(revenue, profit);
+
+  return {
+    revenue,
+    adSpend: totalAdSpend,
+    fixedExpensesPerDay,
+    profit,
+    roas,
+    marginPercent,
+    ordersCount: orders.length,
+    productsCount: products.length
+  };
+};
+
+const getOrders = () => listOrders();
+const getProducts = () => listProducts();
+const getAdSpend = () => listAdSpend();
+const getExpenses = () => listExpenses();
+
+module.exports = {
+  getDashboardMetrics,
+  getOrders,
+  getProducts,
+  getAdSpend,
+  getExpenses
+};

--- a/apps/api/src/logic/metrics.js
+++ b/apps/api/src/logic/metrics.js
@@ -1,0 +1,31 @@
+const calculateRevenue = (orders) =>
+  orders.reduce((total, order) => total + order.total, 0);
+
+const calculateAdSpend = (adSpend) =>
+  adSpend.reduce((total, record) => total + record.amount, 0);
+
+const calculateFixedExpensesPerDay = (expenses, daysInMonth = 30) => {
+  const fixedMonthly = expenses
+    .filter((expense) => expense.type === "fixed" && expense.cadence === "monthly")
+    .reduce((total, expense) => total + expense.amount, 0);
+
+  return daysInMonth > 0 ? fixedMonthly / daysInMonth : 0;
+};
+
+const calculateProfit = (revenue, adSpend, fixedExpensesPerDay) =>
+  revenue - adSpend - fixedExpensesPerDay;
+
+const calculateRoas = (revenue, adSpend) =>
+  adSpend > 0 ? revenue / adSpend : 0;
+
+const calculateMarginPercent = (revenue, profit) =>
+  revenue > 0 ? (profit / revenue) * 100 : 0;
+
+module.exports = {
+  calculateRevenue,
+  calculateAdSpend,
+  calculateFixedExpensesPerDay,
+  calculateProfit,
+  calculateRoas,
+  calculateMarginPercent
+};

--- a/apps/api/src/routes/ads.js
+++ b/apps/api/src/routes/ads.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const { getAdSpend } = require("../logic/dashboard");
+
+const router = express.Router();
+
+router.get("/ads", (req, res) => {
+  const adSpend = getAdSpend();
+  res.json({
+    data: adSpend
+  });
+});
+
+module.exports = router;

--- a/apps/api/src/routes/dashboard.js
+++ b/apps/api/src/routes/dashboard.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const { getDashboardMetrics } = require("../logic/dashboard");
+
+const router = express.Router();
+
+router.get("/dashboard", (req, res) => {
+  const metrics = getDashboardMetrics();
+  res.json({
+    data: metrics
+  });
+});
+
+module.exports = router;

--- a/apps/api/src/routes/expenses.js
+++ b/apps/api/src/routes/expenses.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const { getExpenses } = require("../logic/dashboard");
+
+const router = express.Router();
+
+router.get("/expenses", (req, res) => {
+  const expenses = getExpenses();
+  res.json({
+    data: expenses
+  });
+});
+
+module.exports = router;

--- a/apps/api/src/routes/index.js
+++ b/apps/api/src/routes/index.js
@@ -1,0 +1,16 @@
+const express = require("express");
+const dashboardRoutes = require("./dashboard");
+const ordersRoutes = require("./orders");
+const productsRoutes = require("./products");
+const adsRoutes = require("./ads");
+const expensesRoutes = require("./expenses");
+
+const router = express.Router();
+
+router.use(dashboardRoutes);
+router.use(ordersRoutes);
+router.use(productsRoutes);
+router.use(adsRoutes);
+router.use(expensesRoutes);
+
+module.exports = router;

--- a/apps/api/src/routes/orders.js
+++ b/apps/api/src/routes/orders.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const { getOrders } = require("../logic/dashboard");
+
+const router = express.Router();
+
+router.get("/orders", (req, res) => {
+  const orders = getOrders();
+  res.json({
+    data: orders
+  });
+});
+
+module.exports = router;

--- a/apps/api/src/routes/products.js
+++ b/apps/api/src/routes/products.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const { getProducts } = require("../logic/dashboard");
+
+const router = express.Router();
+
+router.get("/products", (req, res) => {
+  const products = getProducts();
+  res.json({
+    data: products
+  });
+});
+
+module.exports = router;

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,0 +1,7 @@
+const app = require("./app");
+
+const PORT = process.env.PORT || 4000;
+
+app.listen(PORT, () => {
+  console.log(`API listening on port ${PORT}`);
+});

--- a/apps/api/src/services/adSpendService.js
+++ b/apps/api/src/services/adSpendService.js
@@ -1,0 +1,7 @@
+const { adSpend } = require("../db/data");
+
+const listAdSpend = () => adSpend;
+
+module.exports = {
+  listAdSpend
+};

--- a/apps/api/src/services/expensesService.js
+++ b/apps/api/src/services/expensesService.js
@@ -1,0 +1,7 @@
+const { expenses } = require("../db/data");
+
+const listExpenses = () => expenses;
+
+module.exports = {
+  listExpenses
+};

--- a/apps/api/src/services/ordersService.js
+++ b/apps/api/src/services/ordersService.js
@@ -1,0 +1,7 @@
+const { orders } = require("../db/data");
+
+const listOrders = () => orders;
+
+module.exports = {
+  listOrders
+};

--- a/apps/api/src/services/productsService.js
+++ b/apps/api/src/services/productsService.js
@@ -1,0 +1,7 @@
+const { products } = require("../db/data");
+
+const listProducts = () => products;
+
+module.exports = {
+  listProducts
+};


### PR DESCRIPTION
### Motivation
- Provide a small Node.js backend app to surface dashboard metrics and supporting resources for the project.
- Centralize business calculations (revenue, ad spend, expenses, profit, ROAS, margin) in a logic layer so route handlers remain thin. 
- Offer simple mock data and services to enable local development and integration with the frontend.

### Description
- Add an Express app scaffold under `apps/api` with `routes/`, `services/`, `logic/`, and `db/` and an entry `src/server.js` and `package.json` to run the API. 
- Implement mock data in `src/db/data.js` and simple service accessors in `src/services/*Service.js` to isolate data access. 
- Implement calculation utilities in `src/logic/metrics.js` for `calculateRevenue`, `calculateAdSpend`, `calculateFixedExpensesPerDay`, `calculateProfit`, `calculateRoas`, and `calculateMarginPercent` and compose them in `src/logic/dashboard.js`. 
- Expose REST endpoints via `src/routes/*` for `/api/dashboard`, `/api/orders`, `/api/products`, `/api/ads`, and `/api/expenses` where handlers delegate to the logic layer (no business logic in route handlers). 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985fe608c64832a83861122eee60b64)