### PR TITLE
Add SQLite schema, seed data, and DB query layer for metrics

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "sqlite3": "^5.1.7"
   }
 }

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -13,4 +13,9 @@ app.get("/health", (req, res) => {
 
 app.use("/api", routes);
 
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: "Internal server error" });
+});
+
 module.exports = app;

--- a/apps/api/src/db/connection.js
+++ b/apps/api/src/db/connection.js
@@ -1,0 +1,62 @@
+const path = require("path");
+const sqlite3 = require("sqlite3").verbose();
+
+const dbPath = process.env.DB_PATH || path.join(__dirname, "..", "..", "db.sqlite");
+const db = new sqlite3.Database(dbPath);
+
+const run = (sql, params = []) =>
+  new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(this);
+    });
+  });
+
+const get = (sql, params = []) =>
+  new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(row);
+    });
+  });
+
+const all = (sql, params = []) =>
+  new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(rows);
+    });
+  });
+
+const exec = (sql) =>
+  new Promise((resolve, reject) => {
+    db.exec(sql, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+module.exports = {
+  db,
+  dbPath,
+  run,
+  get,
+  all,
+  exec
+};

--- a/apps/api/src/db/migrations/001_init.sql
+++ b/apps/api/src/db/migrations/001_init.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS products (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  price REAL NOT NULL,
+  currency TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  product_id TEXT NOT NULL,
+  quantity INTEGER NOT NULL,
+  total REAL NOT NULL,
+  currency TEXT NOT NULL,
+  ordered_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users (id),
+  FOREIGN KEY (product_id) REFERENCES products (id)
+);
+
+CREATE TABLE IF NOT EXISTS ad_spend (
+  id TEXT PRIMARY KEY,
+  channel TEXT NOT NULL,
+  amount REAL NOT NULL,
+  currency TEXT NOT NULL,
+  spend_date TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS expenses (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  amount REAL NOT NULL,
+  currency TEXT NOT NULL,
+  cadence TEXT NOT NULL,
+  type TEXT NOT NULL,
+  effective_month TEXT,
+  incurred_on TEXT
+);

--- a/apps/api/src/db/queries/index.js
+++ b/apps/api/src/db/queries/index.js
@@ -1,0 +1,56 @@
+const { all, get } = require("../connection");
+
+const fetchOrders = () =>
+  all(
+    `SELECT id, user_id as userId, product_id as productId, quantity, total, currency, ordered_at as orderedAt
+     FROM orders
+     ORDER BY ordered_at`
+  );
+
+const fetchProducts = () =>
+  all(
+    `SELECT id, name, price, currency
+     FROM products
+     ORDER BY name`
+  );
+
+const fetchAdSpend = () =>
+  all(
+    `SELECT id, channel, amount, currency, spend_date as date
+     FROM ad_spend
+     ORDER BY spend_date`
+  );
+
+const fetchExpenses = () =>
+  all(
+    `SELECT id, name, amount, currency, cadence, type, effective_month as effectiveMonth, incurred_on as incurredOn
+     FROM expenses
+     ORDER BY COALESCE(incurred_on, effective_month)`
+  );
+
+const fetchRevenueTotal = async () => {
+  const row = await get("SELECT COALESCE(SUM(total), 0) as revenue FROM orders");
+  return row?.revenue ?? 0;
+};
+
+const fetchAdSpendTotal = async () => {
+  const row = await get("SELECT COALESCE(SUM(amount), 0) as total FROM ad_spend");
+  return row?.total ?? 0;
+};
+
+const fetchFixedMonthlyExpensesTotal = async () => {
+  const row = await get(
+    "SELECT COALESCE(SUM(amount), 0) as total FROM expenses WHERE type = 'fixed' AND cadence = 'monthly'"
+  );
+  return row?.total ?? 0;
+};
+
+module.exports = {
+  fetchOrders,
+  fetchProducts,
+  fetchAdSpend,
+  fetchExpenses,
+  fetchRevenueTotal,
+  fetchAdSpendTotal,
+  fetchFixedMonthlyExpensesTotal
+};

--- a/apps/api/src/db/seed.sql
+++ b/apps/api/src/db/seed.sql
@@ -1,0 +1,27 @@
+INSERT INTO users (id, name, email)
+VALUES
+  ('user_1', 'Avery Powell', 'avery@example.com'),
+  ('user_2', 'Jordan Lee', 'jordan@example.com');
+
+INSERT INTO products (id, name, price, currency)
+VALUES
+  ('prod_1', 'Starter Kit', 120, 'USD'),
+  ('prod_2', 'Growth Bundle', 130, 'USD'),
+  ('prod_3', 'Enterprise Pack', 105, 'USD');
+
+INSERT INTO orders (id, user_id, product_id, quantity, total, currency, ordered_at)
+VALUES
+  ('ord_1001', 'user_1', 'prod_1', 2, 240, 'USD', '2024-05-01'),
+  ('ord_1002', 'user_2', 'prod_2', 1, 130, 'USD', '2024-05-02'),
+  ('ord_1003', 'user_1', 'prod_3', 3, 315, 'USD', '2024-05-03');
+
+INSERT INTO ad_spend (id, channel, amount, currency, spend_date)
+VALUES
+  ('ads_2001', 'Search', 220, 'USD', '2024-05-01'),
+  ('ads_2002', 'Social', 180, 'USD', '2024-05-02');
+
+INSERT INTO expenses (id, name, amount, currency, cadence, type, effective_month, incurred_on)
+VALUES
+  ('exp_3001', 'Software Subscriptions', 900, 'USD', 'monthly', 'fixed', '2024-05', NULL),
+  ('exp_3002', 'Warehouse Rent', 1500, 'USD', 'monthly', 'fixed', '2024-05', NULL),
+  ('exp_3003', 'Packaging', 120, 'USD', 'per-order', 'variable', NULL, '2024-05-01');

--- a/apps/api/src/db/setup.js
+++ b/apps/api/src/db/setup.js
@@ -1,0 +1,46 @@
+const fs = require("fs/promises");
+const path = require("path");
+const { exec, get } = require("./connection");
+
+const migrationsDir = path.join(__dirname, "migrations");
+const seedFile = path.join(__dirname, "seed.sql");
+
+const runSqlFile = async (filePath) => {
+  const sql = await fs.readFile(filePath, "utf-8");
+  if (!sql.trim()) {
+    return;
+  }
+
+  await exec(sql);
+};
+
+const runMigrations = async () => {
+  const files = await fs.readdir(migrationsDir);
+  const migrationFiles = files.filter((file) => file.endsWith(".sql")).sort();
+
+  for (const file of migrationFiles) {
+    await runSqlFile(path.join(migrationsDir, file));
+  }
+};
+
+const isSeeded = async () => {
+  const row = await get("SELECT COUNT(*) as count FROM orders");
+  return row && row.count > 0;
+};
+
+const ensureSeedData = async () => {
+  if (await isSeeded()) {
+    return;
+  }
+
+  await runSqlFile(seedFile);
+};
+
+const setupDatabase = async () => {
+  await runMigrations();
+  await ensureSeedData();
+};
+
+module.exports = {
+  setupDatabase
+};

--- a/apps/api/src/logic/dashboard.js
+++ b/apps/api/src/logic/dashboard.js
@@ -3,23 +3,30 @@ const { listProducts } = require("../services/productsService");
 const { listAdSpend } = require("../services/adSpendService");
 const { listExpenses } = require("../services/expensesService");
 const {
-  calculateRevenue,
-  calculateAdSpend,
+  fetchRevenueTotal,
+  fetchAdSpendTotal,
+  fetchFixedMonthlyExpensesTotal
+} = require("../db/queries");
+const {
   calculateFixedExpensesPerDay,
   calculateProfit,
   calculateRoas,
   calculateMarginPercent
 } = require("./metrics");
 
-const getDashboardMetrics = () => {
-  const orders = listOrders();
-  const products = listProducts();
-  const adSpend = listAdSpend();
-  const expenses = listExpenses();
+const getDashboardMetrics = async () => {
+  const [orders, products, adSpend, expenses, revenue, totalAdSpend, fixedMonthly] =
+    await Promise.all([
+      listOrders(),
+      listProducts(),
+      listAdSpend(),
+      listExpenses(),
+      fetchRevenueTotal(),
+      fetchAdSpendTotal(),
+      fetchFixedMonthlyExpensesTotal()
+    ]);
 
-  const revenue = calculateRevenue(orders);
-  const totalAdSpend = calculateAdSpend(adSpend);
-  const fixedExpensesPerDay = calculateFixedExpensesPerDay(expenses);
+  const fixedExpensesPerDay = calculateFixedExpensesPerDay(fixedMonthly);
   const profit = calculateProfit(revenue, totalAdSpend, fixedExpensesPerDay);
   const roas = calculateRoas(revenue, totalAdSpend);
   const marginPercent = calculateMarginPercent(revenue, profit);

--- a/apps/api/src/logic/metrics.js
+++ b/apps/api/src/logic/metrics.js
@@ -1,16 +1,5 @@
-const calculateRevenue = (orders) =>
-  orders.reduce((total, order) => total + order.total, 0);
-
-const calculateAdSpend = (adSpend) =>
-  adSpend.reduce((total, record) => total + record.amount, 0);
-
-const calculateFixedExpensesPerDay = (expenses, daysInMonth = 30) => {
-  const fixedMonthly = expenses
-    .filter((expense) => expense.type === "fixed" && expense.cadence === "monthly")
-    .reduce((total, expense) => total + expense.amount, 0);
-
-  return daysInMonth > 0 ? fixedMonthly / daysInMonth : 0;
-};
+const calculateFixedExpensesPerDay = (fixedMonthlyTotal, daysInMonth = 30) =>
+  daysInMonth > 0 ? fixedMonthlyTotal / daysInMonth : 0;
 
 const calculateProfit = (revenue, adSpend, fixedExpensesPerDay) =>
   revenue - adSpend - fixedExpensesPerDay;
@@ -22,8 +11,6 @@ const calculateMarginPercent = (revenue, profit) =>
   revenue > 0 ? (profit / revenue) * 100 : 0;
 
 module.exports = {
-  calculateRevenue,
-  calculateAdSpend,
   calculateFixedExpensesPerDay,
   calculateProfit,
   calculateRoas,

--- a/apps/api/src/routes/ads.js
+++ b/apps/api/src/routes/ads.js
@@ -3,11 +3,15 @@ const { getAdSpend } = require("../logic/dashboard");
 
 const router = express.Router();
 
-router.get("/ads", (req, res) => {
-  const adSpend = getAdSpend();
-  res.json({
-    data: adSpend
-  });
+router.get("/ads", async (req, res, next) => {
+  try {
+    const adSpend = await getAdSpend();
+    res.json({
+      data: adSpend
+    });
+  } catch (error) {
+    next(error);
+  }
 });
 
 module.exports = router;

--- a/apps/api/src/routes/dashboard.js
+++ b/apps/api/src/routes/dashboard.js
@@ -3,11 +3,15 @@ const { getDashboardMetrics } = require("../logic/dashboard");
 
 const router = express.Router();
 
-router.get("/dashboard", (req, res) => {
-  const metrics = getDashboardMetrics();
-  res.json({
-    data: metrics
-  });
+router.get("/dashboard", async (req, res, next) => {
+  try {
+    const metrics = await getDashboardMetrics();
+    res.json({
+      data: metrics
+    });
+  } catch (error) {
+    next(error);
+  }
 });
 
 module.exports = router;

--- a/apps/api/src/routes/expenses.js
+++ b/apps/api/src/routes/expenses.js
@@ -3,11 +3,15 @@ const { getExpenses } = require("../logic/dashboard");
 
 const router = express.Router();
 
-router.get("/expenses", (req, res) => {
-  const expenses = getExpenses();
-  res.json({
-    data: expenses
-  });
+router.get("/expenses", async (req, res, next) => {
+  try {
+    const expenses = await getExpenses();
+    res.json({
+      data: expenses
+    });
+  } catch (error) {
+    next(error);
+  }
 });
 
 module.exports = router;

--- a/apps/api/src/routes/orders.js
+++ b/apps/api/src/routes/orders.js
@@ -3,11 +3,15 @@ const { getOrders } = require("../logic/dashboard");
 
 const router = express.Router();
 
-router.get("/orders", (req, res) => {
-  const orders = getOrders();
-  res.json({
-    data: orders
-  });
+router.get("/orders", async (req, res, next) => {
+  try {
+    const orders = await getOrders();
+    res.json({
+      data: orders
+    });
+  } catch (error) {
+    next(error);
+  }
 });
 
 module.exports = router;

--- a/apps/api/src/routes/products.js
+++ b/apps/api/src/routes/products.js
@@ -3,11 +3,15 @@ const { getProducts } = require("../logic/dashboard");
 
 const router = express.Router();
 
-router.get("/products", (req, res) => {
-  const products = getProducts();
-  res.json({
-    data: products
-  });
+router.get("/products", async (req, res, next) => {
+  try {
+    const products = await getProducts();
+    res.json({
+      data: products
+    });
+  } catch (error) {
+    next(error);
+  }
 });
 
 module.exports = router;

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,7 +1,15 @@
 const app = require("./app");
+const { setupDatabase } = require("./db/setup");
 
 const PORT = process.env.PORT || 4000;
 
-app.listen(PORT, () => {
-  console.log(`API listening on port ${PORT}`);
-});
+setupDatabase()
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`API listening on port ${PORT}`);
+    });
+  })
+  .catch((error) => {
+    console.error("Failed to initialize database", error);
+    process.exit(1);
+  });

--- a/apps/api/src/services/adSpendService.js
+++ b/apps/api/src/services/adSpendService.js
@@ -1,6 +1,6 @@
-const { adSpend } = require("../db/data");
+const { fetchAdSpend } = require("../db/queries");
 
-const listAdSpend = () => adSpend;
+const listAdSpend = () => fetchAdSpend();
 
 module.exports = {
   listAdSpend

--- a/apps/api/src/services/expensesService.js
+++ b/apps/api/src/services/expensesService.js
@@ -1,6 +1,6 @@
-const { expenses } = require("../db/data");
+const { fetchExpenses } = require("../db/queries");
 
-const listExpenses = () => expenses;
+const listExpenses = () => fetchExpenses();
 
 module.exports = {
   listExpenses

--- a/apps/api/src/services/ordersService.js
+++ b/apps/api/src/services/ordersService.js
@@ -1,6 +1,6 @@
-const { orders } = require("../db/data");
+const { fetchOrders } = require("../db/queries");
 
-const listOrders = () => orders;
+const listOrders = () => fetchOrders();
 
 module.exports = {
   listOrders

--- a/apps/api/src/services/productsService.js
+++ b/apps/api/src/services/productsService.js
@@ -1,6 +1,6 @@
-const { products } = require("../db/data");
+const { fetchProducts } = require("../db/queries");
 
-const listProducts = () => products;
+const listProducts = () => fetchProducts();
 
 module.exports = {
   listProducts


### PR DESCRIPTION
### Motivation
- Provide a small local SQLite-backed data store for the API so metrics are driven by real data rather than in-memory fixtures.
- Persist `users`, `products`, `orders`, `ad_spend`, and `expenses` and support monthly fixed expenses that can be distributed to a per-day value in the logic layer.
- Expose aggregate fetches (revenue, ad spend, fixed-monthly totals) so dashboard calculations are accurate and efficient.

### Description
- Added `sqlite3` to `apps/api/package.json` and introduced a database connection helper `apps/api/src/db/connection.js` that wraps `run`, `get`, `all`, and `exec` with promises.
- Added SQL migration `apps/api/src/db/migrations/001_init.sql` to create `users`, `products`, `orders`, `ad_spend`, and `expenses` tables and seed file `apps/api/src/db/seed.sql` with sample MVP data.
- Added `apps/api/src/db/setup.js` to run migrations and seed once, and wired `setupDatabase()` to run before the server starts in `apps/api/src/server.js`.
- Implemented a query layer `apps/api/src/db/queries/index.js` with `fetchOrders`, `fetchProducts`, `fetchAdSpend`, `fetchExpenses` and aggregate helpers `fetchRevenueTotal`, `fetchAdSpendTotal`, and `fetchFixedMonthlyExpensesTotal`.
- Migrated service modules (`ordersService`, `productsService`, `adSpendService`, `expensesService`) to use the new query functions and updated routes to async handlers with error propagation.
- Updated metrics logic to accept a fixed monthly total and compute a per-day fixed expense via `calculateFixedExpensesPerDay` in `apps/api/src/logic/metrics.js`, and updated the dashboard to consume DB aggregates in `apps/api/src/logic/dashboard.js`.
- Added a basic error handler middleware in `apps/api/src/app.js` to return a 500 JSON response on unexpected errors.

### Testing
- No automated tests were run against the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ff8c1290832a88092806445eec94)