### PR TITLE
Add authentication (sessions + password hashing), protect finance APIs, and add login UI

### DIFF
--- a/apps/api/src/db/migrations/002_auth.sql
+++ b/apps/api/src/db/migrations/002_auth.sql
@@ -1,0 +1,14 @@
+ALTER TABLE users ADD COLUMN hashed_password TEXT;
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  token TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+UPDATE users
+SET hashed_password = 'seeded-salt:575bc12c7a0214ebfe610969c4121e72faede66e244754f0a036fdb0810bf8ef20e9d1e483f853febd0ddf8b4cd806f8583c3543f4ace2d338103e1204e78e12'
+WHERE hashed_password IS NULL OR hashed_password = '';

--- a/apps/api/src/db/queries/auth.js
+++ b/apps/api/src/db/queries/auth.js
@@ -1,0 +1,42 @@
+const { get, run } = require("../connection");
+
+const findUserByEmail = (email) =>
+  get(
+    "SELECT id, name, email, hashed_password as hashedPassword FROM users WHERE email = ?",
+    [email]
+  );
+
+const createUser = ({ id, name, email, hashedPassword }) =>
+  run("INSERT INTO users (id, name, email, hashed_password) VALUES (?, ?, ?, ?)", [
+    id,
+    name,
+    email,
+    hashedPassword
+  ]);
+
+const createSession = ({ id, userId, token, expiresAt }) =>
+  run(
+    "INSERT INTO sessions (id, user_id, token, expires_at) VALUES (?, ?, ?, ?)",
+    [id, userId, token, expiresAt]
+  );
+
+const findSessionByToken = (token) =>
+  get(
+    `SELECT sessions.id, sessions.user_id as userId, sessions.expires_at as expiresAt,
+            users.name as name, users.email as email
+     FROM sessions
+     JOIN users ON users.id = sessions.user_id
+     WHERE sessions.token = ?`,
+    [token]
+  );
+
+const deleteSessionByToken = (token) =>
+  run("DELETE FROM sessions WHERE token = ?", [token]);
+
+module.exports = {
+  findUserByEmail,
+  createUser,
+  createSession,
+  findSessionByToken,
+  deleteSessionByToken
+};

--- a/apps/api/src/db/seed.sql
+++ b/apps/api/src/db/seed.sql
@@ -1,7 +1,7 @@
-INSERT INTO users (id, name, email)
+INSERT INTO users (id, name, email, hashed_password)
 VALUES
-  ('user_1', 'Avery Powell', 'avery@example.com'),
-  ('user_2', 'Jordan Lee', 'jordan@example.com');
+  ('user_1', 'Avery Powell', 'avery@example.com', 'seeded-salt:575bc12c7a0214ebfe610969c4121e72faede66e244754f0a036fdb0810bf8ef20e9d1e483f853febd0ddf8b4cd806f8583c3543f4ace2d338103e1204e78e12'),
+  ('user_2', 'Jordan Lee', 'jordan@example.com', 'seeded-salt:575bc12c7a0214ebfe610969c4121e72faede66e244754f0a036fdb0810bf8ef20e9d1e483f853febd0ddf8b4cd806f8583c3543f4ace2d338103e1204e78e12');
 
 INSERT INTO products (id, name, price, currency)
 VALUES

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,0 +1,39 @@
+const { findSessionByToken, deleteSessionByToken } = require("../db/queries/auth");
+
+const requireAuth = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const session = await findSessionByToken(token);
+    if (!session) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    if (new Date(session.expiresAt) <= new Date()) {
+      await deleteSessionByToken(token);
+      res.status(401).json({ error: "Session expired" });
+      return;
+    }
+
+    req.user = {
+      id: session.userId,
+      name: session.name,
+      email: session.email
+    };
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  requireAuth
+};

--- a/apps/api/src/routes/ads.js
+++ b/apps/api/src/routes/ads.js
@@ -1,9 +1,10 @@
 const express = require("express");
 const { getAdSpend } = require("../logic/dashboard");
+const { requireAuth } = require("../middleware/auth");
 
 const router = express.Router();
 
-router.get("/ads", async (req, res, next) => {
+router.get("/ads", requireAuth, async (req, res, next) => {
   try {
     const adSpend = await getAdSpend();
     res.json({

--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -1,0 +1,100 @@
+const express = require("express");
+const crypto = require("crypto");
+const {
+  createUser,
+  findUserByEmail,
+  createSession,
+  deleteSessionByToken
+} = require("../db/queries/auth");
+const { hashPassword, verifyPassword } = require("../utils/passwords");
+
+const router = express.Router();
+
+const issueSession = async (user) => {
+  const token = crypto.randomBytes(32).toString("hex");
+  const sessionId = `sess_${crypto.randomUUID()}`;
+  const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString();
+
+  await createSession({ id: sessionId, userId: user.id, token, expiresAt });
+
+  return {
+    token,
+    user: {
+      id: user.id,
+      name: user.name,
+      email: user.email
+    }
+  };
+};
+
+router.post("/auth/signup", async (req, res, next) => {
+  try {
+    const { name, email, password } = req.body || {};
+
+    if (!name || !email || !password) {
+      res.status(400).json({ error: "Name, email, and password are required." });
+      return;
+    }
+
+    const existingUser = await findUserByEmail(email);
+    if (existingUser) {
+      res.status(409).json({ error: "Email already in use." });
+      return;
+    }
+
+    const hashedPassword = await hashPassword(password);
+    const userId = `user_${crypto.randomUUID()}`;
+
+    await createUser({ id: userId, name, email, hashedPassword });
+
+    const authPayload = await issueSession({ id: userId, name, email });
+    res.status(201).json(authPayload);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/auth/login", async (req, res, next) => {
+  try {
+    const { email, password } = req.body || {};
+
+    if (!email || !password) {
+      res.status(400).json({ error: "Email and password are required." });
+      return;
+    }
+
+    const user = await findUserByEmail(email);
+    if (!user) {
+      res.status(401).json({ error: "Invalid credentials." });
+      return;
+    }
+
+    const isValid = await verifyPassword(password, user.hashedPassword);
+    if (!isValid) {
+      res.status(401).json({ error: "Invalid credentials." });
+      return;
+    }
+
+    const authPayload = await issueSession(user);
+    res.json(authPayload);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/auth/logout", async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+    if (token) {
+      await deleteSessionByToken(token);
+    }
+
+    res.json({ status: "ok" });
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/apps/api/src/routes/dashboard.js
+++ b/apps/api/src/routes/dashboard.js
@@ -1,9 +1,10 @@
 const express = require("express");
 const { getDashboardMetrics } = require("../logic/dashboard");
+const { requireAuth } = require("../middleware/auth");
 
 const router = express.Router();
 
-router.get("/dashboard", async (req, res, next) => {
+router.get("/dashboard", requireAuth, async (req, res, next) => {
   try {
     const metrics = await getDashboardMetrics();
     res.json({

--- a/apps/api/src/routes/expenses.js
+++ b/apps/api/src/routes/expenses.js
@@ -1,9 +1,10 @@
 const express = require("express");
 const { getExpenses } = require("../logic/dashboard");
+const { requireAuth } = require("../middleware/auth");
 
 const router = express.Router();
 
-router.get("/expenses", async (req, res, next) => {
+router.get("/expenses", requireAuth, async (req, res, next) => {
   try {
     const expenses = await getExpenses();
     res.json({

--- a/apps/api/src/routes/index.js
+++ b/apps/api/src/routes/index.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const authRoutes = require("./auth");
 const dashboardRoutes = require("./dashboard");
 const ordersRoutes = require("./orders");
 const productsRoutes = require("./products");
@@ -7,6 +8,7 @@ const expensesRoutes = require("./expenses");
 
 const router = express.Router();
 
+router.use(authRoutes);
 router.use(dashboardRoutes);
 router.use(ordersRoutes);
 router.use(productsRoutes);

--- a/apps/api/src/routes/orders.js
+++ b/apps/api/src/routes/orders.js
@@ -1,9 +1,10 @@
 const express = require("express");
 const { getOrders } = require("../logic/dashboard");
+const { requireAuth } = require("../middleware/auth");
 
 const router = express.Router();
 
-router.get("/orders", async (req, res, next) => {
+router.get("/orders", requireAuth, async (req, res, next) => {
   try {
     const orders = await getOrders();
     res.json({

--- a/apps/api/src/utils/passwords.js
+++ b/apps/api/src/utils/passwords.js
@@ -1,0 +1,34 @@
+const crypto = require("crypto");
+const { promisify } = require("util");
+
+const scrypt = promisify(crypto.scrypt);
+
+const hashPassword = async (password) => {
+  const salt = crypto.randomBytes(16).toString("hex");
+  const derivedKey = await scrypt(password, salt, 64);
+  return `${salt}:${derivedKey.toString("hex")}`;
+};
+
+const verifyPassword = async (password, storedValue) => {
+  if (!storedValue) {
+    return false;
+  }
+
+  const [salt, key] = storedValue.split(":");
+  if (!salt || !key) {
+    return false;
+  }
+
+  const derivedKey = await scrypt(password, salt, 64);
+  const storedKey = Buffer.from(key, "hex");
+  if (storedKey.length !== derivedKey.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(storedKey, derivedKey);
+};
+
+module.exports = {
+  hashPassword,
+  verifyPassword
+};

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import { Sidebar } from '@/components/Sidebar';
+import { AuthShell } from '@/components/AuthShell';
 
 export const metadata: Metadata = {
   title: 'Commerce Hub',
@@ -11,10 +11,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="min-h-screen bg-slate-50">
-        <div className="flex min-h-screen">
-          <Sidebar />
-          <div className="flex w-full flex-1 flex-col">{children}</div>
-        </div>
+        <AuthShell>{children}</AuthShell>
       </body>
     </html>
   );

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getApiBaseUrl, setAuthToken } from '@/lib/auth';
+
+const initialForm = {
+  name: '',
+  email: '',
+  password: ''
+};
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [mode, setMode] = useState<'login' | 'signup'>('login');
+  const [form, setForm] = useState(initialForm);
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setForm((prev) => ({
+      ...prev,
+      [event.target.name]: event.target.value
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError('');
+    setIsSubmitting(true);
+
+    try {
+      const endpoint = mode === 'signup' ? '/auth/signup' : '/auth/login';
+      const payload =
+        mode === 'signup'
+          ? { name: form.name.trim(), email: form.email.trim(), password: form.password }
+          : { email: form.email.trim(), password: form.password };
+
+      const response = await fetch(`${getApiBaseUrl()}${endpoint}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        setError(data?.error ?? 'Unable to authenticate.');
+        setIsSubmitting(false);
+        return;
+      }
+
+      if (data?.token) {
+        setAuthToken(data.token);
+      }
+
+      router.replace('/');
+    } catch (err) {
+      setError('Something went wrong. Please try again.');
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-6 py-12">
+      <div className="w-full max-w-md rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Commerce Hub</p>
+        <h1 className="mt-4 text-2xl font-semibold text-slate-900">
+          {mode === 'signup' ? 'Create your account' : 'Welcome back'}
+        </h1>
+        <p className="mt-2 text-sm text-slate-500">
+          {mode === 'signup'
+            ? 'Start monitoring your revenue in minutes.'
+            : 'Log in to review your financial performance.'}
+        </p>
+
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+          {mode === 'signup' && (
+            <label className="block text-sm font-medium text-slate-600">
+              Full name
+              <input
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                required
+                className="mt-2 w-full rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none"
+                placeholder="Avery Powell"
+              />
+            </label>
+          )}
+          <label className="block text-sm font-medium text-slate-600">
+            Email
+            <input
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+              className="mt-2 w-full rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none"
+              placeholder="you@example.com"
+            />
+          </label>
+          <label className="block text-sm font-medium text-slate-600">
+            Password
+            <input
+              type="password"
+              name="password"
+              value={form.password}
+              onChange={handleChange}
+              required
+              minLength={6}
+              className="mt-2 w-full rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-900 focus:border-brand-500 focus:outline-none"
+              placeholder="••••••••"
+            />
+          </label>
+
+          {error && <p className="text-sm text-rose-500">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-full bg-brand-500 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-600 disabled:cursor-not-allowed disabled:bg-brand-300"
+          >
+            {isSubmitting ? 'Working…' : mode === 'signup' ? 'Create account' : 'Sign in'}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center text-sm text-slate-500">
+          {mode === 'signup' ? 'Already have an account?' : 'New to Commerce Hub?'}{' '}
+          <button
+            type="button"
+            onClick={() => {
+              setMode(mode === 'signup' ? 'login' : 'signup');
+              setError('');
+            }}
+            className="font-semibold text-brand-500"
+          >
+            {mode === 'signup' ? 'Sign in' : 'Create one'}
+          </button>
+        </div>
+
+        <div className="mt-6 rounded-2xl bg-slate-50 p-4 text-xs text-slate-500">
+          <p className="font-semibold text-slate-700">Demo access</p>
+          <p className="mt-2">Use a seeded account like avery@example.com with password123.</p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/AuthShell.tsx
+++ b/apps/web/src/components/AuthShell.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { Sidebar } from '@/components/Sidebar';
+import { getAuthToken } from '@/lib/auth';
+
+const PUBLIC_ROUTES = ['/login'];
+
+export function AuthShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [isReady, setIsReady] = useState(false);
+  const isPublicRoute = useMemo(() => PUBLIC_ROUTES.includes(pathname), [pathname]);
+
+  useEffect(() => {
+    const token = getAuthToken();
+
+    if (!token && !isPublicRoute) {
+      router.replace('/login');
+      setIsReady(true);
+      return;
+    }
+
+    if (token && isPublicRoute) {
+      router.replace('/');
+      setIsReady(true);
+      return;
+    }
+
+    setIsReady(true);
+  }, [isPublicRoute, router]);
+
+  if (!isReady) {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-slate-500">
+        Loading…
+      </div>
+    );
+  }
+
+  if (isPublicRoute) {
+    return <div className="min-h-screen bg-slate-50">{children}</div>;
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex w-full flex-1 flex-col">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,28 @@
+const TOKEN_KEY = 'engine9r_auth_token';
+
+export const getAuthToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.localStorage.getItem(TOKEN_KEY);
+};
+
+export const setAuthToken = (token: string) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(TOKEN_KEY, token);
+};
+
+export const clearAuthToken = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.removeItem(TOKEN_KEY);
+};
+
+export const getApiBaseUrl = () =>
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000/api';


### PR DESCRIPTION
### Motivation
- Add simple user authentication with hashed passwords and session tokens so demo users can sign up, sign in, and access protected financial endpoints. 
- Protect sensitive routes that return revenue/ads/expenses/orders data behind authentication to prevent public access. 
- Provide a minimal frontend login/signup experience and client-side route guard to demo the flow. 

### Description
- Add database migration `002_auth.sql` and update seed data to include a `hashed_password` for seeded users and create a `sessions` table for server-side session tokens.`
- Implement password helpers in `apps/api/src/utils/passwords.js` using `scrypt` and new DB queries in `apps/api/src/db/queries/auth.js` for user/session operations.`
- Add auth endpoints in `apps/api/src/routes/auth.js` for `POST /auth/signup`, `POST /auth/login`, and `POST /auth/logout`, and middleware `apps/api/src/middleware/auth.js` that validates `Bearer` tokens and attaches `req.user`.
- Protect finance-related routes by applying the middleware to `dashboard`, `orders`, `ads`, and `expenses` routes and register the `auth` routes in `apps/api/src/routes/index.js`.
- Add frontend support: token helpers in `apps/web/src/lib/auth.ts`, a client-side `AuthShell` in `apps/web/src/components/AuthShell.tsx` to guard routes, and a login/signup page at `apps/web/src/app/login/page.tsx`, plus wire the shell into `apps/web/src/app/layout.tsx`.

### Testing
- Attempted to install frontend dependencies with `npm install` in `apps/web`, but the command failed with a `403 Forbidden` from the registry so the dev server and end-to-end verification were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860139c7bc832abb14ac46000c4dd6)